### PR TITLE
Implement Batch Resume Parsing Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,67 @@ Set the environment variable `YOUR_NAME` to your name to have the app display yo
 ## NGINX/Reverse Proxy
 
 The `nginx.conf` file can be used to configure an NGINX container to run as a reverse proxy to the Flask app container, effectively making the Flask application accessible on port `80`. You will need to know how to configure networks in Docker in order to achieve this.
+
+```
+
+# Batch Resume Parsing
+
+This project supports batch parsing of resumes from PDFs, DOCX, and TXT files.
+
+## Installing Dependencies
+
+Make sure to install the new dependencies:
+```
+pip install -r requirements.txt
+```
+
+## Using the CLI
+
+To parse all resumes under a directory, run:
+```
+python scripts/batch_resume_parser.py --input /path/to/resume/dir --output results.json
+```
+If you omit `--output`, the results will print to stdout.
+
+## Using the API
+
+A Flask API endpoint is available:
+
+```
+POST /api/parse-resumes
+Content-Type: multipart/form-data
+Field: files (multiple file upload)
+```
+
+Example using `curl`:
+```
+curl -X POST http://localhost:5500/api/parse-resumes \
+  -F "files=@/path/to/john_resume.pdf" \
+  -F "files=@/path/to/jane_resume.docx"
+```
+The response will be:
+```json
+{
+  "results": [
+    {
+      "filename": "john_resume.pdf",
+      "data": {
+        "name": "John Doe",
+        "email": "john@example.com",
+        "phone": "+1-555-123-4567",
+        "skills": ["Python", "Leadership", "..."],
+        "raw_text": "...full resume text..."
+      }
+    },
+    {
+      "filename": "jane_resume.docx",
+      "data": {
+        ...
+      }
+    }
+  ]
+}
+```
+If a file fails to parse, `"error"` will be present instead of `"data"`.
+
+CORS is enabled by default, so you can call this API from your frontend app.

--- a/app.py
+++ b/app.py
@@ -3,9 +3,19 @@ Flask backend for Duo Task.
 Now serves as both API and static file host for React SPA.
 '''
 import os
+import tempfile
 from flask import Flask, jsonify, send_from_directory, request
 
+from flask_cors import CORS
+
 app = Flask(__name__, static_folder='react-build', static_url_path='')
+CORS(app)
+
+try:
+    from scripts.resume_parser import parse_resume
+except ImportError:
+    # For local dev, allow app to run even if resume_parser isn't available yet
+    parse_resume = None
 
 def get_greeting_msg():
     hostname = os.getenv('HOSTNAME')
@@ -29,6 +39,32 @@ def serve_react(path):
         return send_from_directory(root_dir, path)
     # Otherwise, serve index.html for SPA client routing
     return send_from_directory(root_dir, 'index.html')
+
+@app.route("/api/parse-resumes", methods=["POST"])
+def api_parse_resumes():
+    if parse_resume is None:
+        return jsonify({"error": "Resume parser module not available"}), 500
+    results = []
+    files = request.files.getlist("files")
+    for f in files:
+        temp = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            f.save(temp.name)
+            try:
+                data = parse_resume(temp.name)
+                results.append({
+                    "filename": f.filename,
+                    "data": data
+                })
+            except Exception as e:
+                results.append({
+                    "filename": f.filename,
+                    "error": str(e)
+                })
+        finally:
+            temp.close()
+            os.unlink(temp.name)
+    return jsonify({"results": results})
 
 if __name__=='__main__':
     app.run(host='0.0.0.0', port=5500, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 Flask>=2.2,<3
 Jinja2<3.1
+pdfminer.six>=20221105
+docx2txt>=0.8
+tqdm>=4.66
+Flask-CORS>=4.0

--- a/scripts/batch_resume_parser.py
+++ b/scripts/batch_resume_parser.py
@@ -1,0 +1,43 @@
+import os
+import argparse
+import json
+from tqdm import tqdm
+
+from scripts.resume_parser import parse_resume
+
+def find_resume_files(root):
+    for dirpath, _, filenames in os.walk(root):
+        for fname in filenames:
+            if fname.lower().endswith(('.pdf', '.docx', '.txt')):
+                yield os.path.relpath(os.path.join(dirpath, fname), root)
+
+def main():
+    parser = argparse.ArgumentParser(description="Batch parse resumes in a directory.")
+    parser.add_argument('--input', required=True, help='Input directory')
+    parser.add_argument('--output', help='Output JSON file (default: stdout)')
+    args = parser.parse_args()
+
+    files = list(find_resume_files(args.input))
+    results = []
+    for rel_path in tqdm(files, desc="Parsing resumes"):
+        abs_path = os.path.join(args.input, rel_path)
+        try:
+            data = parse_resume(abs_path)
+            results.append({
+                "filename": rel_path,
+                "data": data
+            })
+        except Exception as e:
+            results.append({
+                "filename": rel_path,
+                "error": str(e)
+            })
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2, ensure_ascii=False)
+    else:
+        print(json.dumps(results, indent=2, ensure_ascii=False))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/resume_parser.py
+++ b/scripts/resume_parser.py
@@ -1,0 +1,64 @@
+import os
+import re
+
+SKILLS = [
+    "Python", "Java", "C++", "C#", "JavaScript", "TypeScript", "SQL", "NoSQL", "Ruby", "Go", "Rust", "Scala", "Kotlin",
+    "PHP", "HTML", "CSS", "React", "Angular", "Vue", "Django", "Flask", "Spring", "Node.js", "Express", "AWS", "Azure",
+    "GCP", "Docker", "Kubernetes", "Git", "Linux", "Bash", "Agile", "Scrum", "Kanban", "Leadership", "Communication",
+    "Problem-solving", "Teamwork", "Time management", "Adaptability", "Critical thinking", "Machine Learning",
+    "Deep Learning", "Data Analysis", "Data Science", "TensorFlow", "PyTorch", "Pandas", "NumPy", "Excel",
+    "Project Management", "Creativity"
+]
+
+def extract_text(path: str) -> str:
+    _, ext = os.path.splitext(path)
+    ext = ext.lower()
+    if ext == ".pdf":
+        from pdfminer.high_level import extract_text as pdf_extract_text
+        return pdf_extract_text(path)
+    elif ext == ".docx":
+        import docx2txt
+        return docx2txt.process(path)
+    elif ext == ".txt":
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            return f.read()
+    else:
+        raise ValueError(f"Unsupported file extension: {ext}")
+
+def find_matches(pattern, text):
+    return re.findall(pattern, text, flags=re.IGNORECASE | re.MULTILINE)
+
+def parse_resume(path: str) -> dict:
+    text = extract_text(path)
+    lines = [line.strip() for line in text.splitlines()]
+    name = next((line for line in lines if line), None) or ""
+    email_pattern = r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+"
+    email_matches = find_matches(email_pattern, text)
+    email = email_matches[0] if email_matches else ""
+    phone_pattern = (
+        r"(\+?\d{1,3}[-.\s]?)?(\(?\d{3,4}\)?[-.\s]?)?\d{3}[-.\s]?\d{4,6}"
+    )
+    phone_matches = find_matches(phone_pattern, text)
+    phone = ""
+    if phone_matches:
+        # Flatten tuple results and join
+        for match in phone_matches:
+            if isinstance(match, tuple):
+                phone = "".join(match).strip()
+                if phone:
+                    break
+            else:
+                phone = match.strip()
+                break
+    found_skills = []
+    text_lower = text.lower()
+    for skill in SKILLS:
+        if skill.lower() in text_lower and skill not in found_skills:
+            found_skills.append(skill)
+    return {
+        "name": name,
+        "email": email,
+        "phone": phone,
+        "skills": found_skills,
+        "raw_text": text
+    }


### PR DESCRIPTION
This pull request introduces functionality for batch parsing resumes in various formats (PDF, DOCX, TXT). The changes include:

1. **New Scripts**: Added a `batch_resume_parser.py` script that allows users to batch process resumes in a specified directory and save results in JSON format.

2. **API Endpoint**: Extended the Flask API by adding a new endpoint `/api/parse-resumes` that supports uploading multiple resume files for parsing.

3. **Resume Parser Module**: Created a `resume_parser.py` module that extracts key information like name, email, phone, and skills from resumes.

4. **Updated Requirements**: Modified `requirements.txt` to include new dependencies needed for parsing different file types.

5. **Documentation**: Updated the `README.md` to reflect these changes, including usage instructions for both the command line interface and the API.

These enhancements solve the issue of single-file processing by allowing users to handle multiple resumes simultaneously, improving the efficiency of the resume parsing process.

---

> This pull request was co-created with Cosine Genie

Original Task: [qa_final/9qvdyqwg0y5c](https://cosine.sh/wiai8elj4rd6/qa_final/task/9qvdyqwg0y5c)
Author: Khaled Eladl
